### PR TITLE
Dusan Baljevic Solaris simplified detailed-process-stat.pl plugin, added...

### DIFF
--- a/sunos/cfg2html-SunOS.sh
+++ b/sunos/cfg2html-SunOS.sh
@@ -658,6 +658,8 @@ then # else skip to next paragraph
 
    exec_command "lshal" "HAL devices"
 
+   exec_command "devreserv" "Devices currently reserved for exclusive use"
+
    exec_command "iostat -En" "I/O device error status"
 
    exec_command "stmsboot -L" "Solaris I/O multipathing (STMS and MPxIO)"
@@ -945,7 +947,7 @@ EOF
 
    exec_command "croinfo" "Chassis, Receptacle and Occupant info"
  
-   exec_command "diskinfo" "Diskinfo"
+   exec_command "diskinfo -v | nawk NF" "Diskinfo"
 
    dec_heading_level
 fi

--- a/sunos/plugins/detailed-process-stat.pl
+++ b/sunos/plugins/detailed-process-stat.pl
@@ -5,7 +5,7 @@ eval 'exec perl -S $0 ${1+"$@"} 2>/dev/null'
 # Designed by:  Dusan U. Baljevic (dusan.baljevic@ieee.org)
 # Coded by:     Dusan U. Baljevic (dusan.baljevic@ieee.org)
 
-$ENV{'PATH'} = "/usr/bin:/usr/sbin:/sbin:/bin:/usr/ccs/bin:/etc";
+$ENV{'PATH'} = "/usr/bin:/usr/sbin:/sbin:/bin";
 
 use strict;
 
@@ -20,33 +20,30 @@ my @PSPROC   = ();
 my @PSZOMBIE = (); 
 my @PSREST   = (); 
 my $PSFLAG   = q{};
-my $System   = q{}; 
 my $Hostname = q{};
 my $Maj      = q{};
 my $Version  = q{};
-my $Hardware = q{};
 my $Major    = q{};
 my $Minor    = q{};
-my $Patch    = q{};
 
 if ( eval "require POSIX" ) {
    import POSIX 'uname';
    import POSIX qw(locale_h);
-   ( $System, $Hostname, $Maj, $Version, $Hardware ) = uname();
+   ( undef, $Hostname, $Maj, $Version, undef ) = uname();
    if ("$Maj") {
-      ( $Major, $Minor, $Patch ) = split( /\./, $Maj );
+      ( $Major, $Minor, undef ) = split( /\./, $Maj );
    }
 }
 
 if ( !"$Hostname" ) {
     my $VH = `uname -a 2>&1`;
-    ( $System, $Hostname, $Maj, undef, $Hardware, undef ) =
+    ( undef, $Hostname, $Maj, undef, undef, undef ) =
       split( /\s+/, $VH );
     $Version = $Maj;
-    ( $Major, $Minor, $Patch ) = split( /\./, $Maj );
+    ( $Major, $Minor, undef ) = split( /\./, $Maj );
 }
 
-if ( "$Major" >= 10 ) {
+if ( "$Minor" >= 10 ) {
    $PSFLAG="Z";
 }
 
@@ -87,14 +84,14 @@ if ( open( KM, "ps -efl${PSFLAG} |" ) ) {
          }
       }
 
-      if ( "$Major" >= 10 ) {
-         if( $userid[3] =~ /^[0-9]+$/ ) {
-            print "WARN: Process \"$psline\" without owner defined in password database (\"$userid[3]\")\n";
+      if ( "$Minor" >= 10 ) {
+         if( $userid[4] =~ /^[0-9]+$/ ) {
+            print "WARN: Process \"$psline\" without owner defined in password database (\"$userid[4]\")\n";
          }
       }
       else {
-         if( $userid[2] =~ /^[0-9]+$/ ) {
-            print "WARN: Process \"$psline\" without owner defined in password database (\"$userid[2]\")\n";
+         if( $userid[3] =~ /^[0-9]+$/ ) {
+            print "WARN: Process \"$psline\" without owner defined in password database (\"$userid[3]\")\n";
          }
       }
    }


### PR DESCRIPTION
... diskinfo verbosity and Solaris 8 command devreserv

Hello Ralph and Gratien,

I cleaned up the RCS tree so that they do not affect the source tree at GIThub.

I also updated the Perl and Shell script with some additions.

A quick question as I would like to add some Perl plugin scripts for Linux. HP-UX and Solaris have subdirectory named "plugins" in the source tree but AIX and Linux do not. 

I know that Didac will work on Makefile for AIX soon. And becvause AIX has no plugin scripts
it is easy to introduce standardisation (rename ASCII file plugins into something else and create directory plugins).

In fact, Linux top-level Makefile points to subdirectory plugins but it cannot be created because there is an ASCII file with the same name! Should we have consistent directory structure?

To me, it seems that best option would be to have subdir named plugins. Does that make sense?

Cheers,

Dusan Baljevic VK2COT
