### PR TITLE
needed directories for make deb

### DIFF
--- a/linux/packaging/debian/rules
+++ b/linux/packaging/debian/rules
@@ -65,7 +65,7 @@ binary-indep: build
 		debian/cfg2html/etc/cfg2html/ \
 		debian/cfg2html/etc/cron.d/ \
 		debian/cfg2html/usr/sbin/ \
-		debian/cfg2html/usr/share/cfg2html/ \
+		debian/cfg2html/usr/share/cfg2html/etc/cfg2html \
 		debian/cfg2html/var/log/cfg2html/
 
 


### PR DESCRIPTION
when make deb, there is no directoires for build-dep , so I added rules file  debian/cfg2html/usr/share/cfg2html/etc/cfg2html