### PR TITLE
Further MTA updates for Linux version

### DIFF
--- a/linux/cfg2html-linux.sh
+++ b/linux/cfg2html-linux.sh
@@ -1330,8 +1330,8 @@ then # else skip to next paragraph
   then
         :               ##  provides sendmail which NO options
   else
-      if [ -d /etc/alternatives ]; then
-          MTA=$(alternatives --list | grep mta | cut -d'        ' -f3)
+      if [ -L /etc/alternatives/mta ]; then
+          MTA=$(readlink -e /etc/alternatives/mta)
       else
           MTA=''
       fi


### PR DESCRIPTION
This fix should take care of the alternatives issue with earlier Linux versions.  It now directly tests the symlink rather than calling alternatives.