### PR TITLE
fix installability

### DIFF
--- a/linux/cfg2html-linux.sh
+++ b/linux/cfg2html-linux.sh
@@ -545,9 +545,6 @@ inc_heading_level
     exec_command "lsof -nP 2>\/dev\/null | grep '(deleted)'" "Files that are open but have been deleted" # modified on 20201026 by edrulrd
   fi # terminates CFG_LSOFDEL wrapper # added on 20201026 by edrulrd
 
-  exec_command "lsof -nP 2>\/dev\/null | grep '(deleted)'" "Files that are open but have been deleted" # modified on 20201026 by edrulrd
-
-
   # In "used memory.swap" section I would add :
   # free -tl     (instead of free, because it gives some more useful infos, about HighMem and LowMem memory regions (zones))
   # cat /proc/meminfo (in order to get some details of memory usage)

--- a/linux/packaging/debian/rules
+++ b/linux/packaging/debian/rules
@@ -85,7 +85,11 @@ binary-indep: build
        # This triggers issue #35 on the SUSE OBS environment ....
        # [   77s] cp -av etc/default.conf debian/cfg2html/usr/share/cfg2html/etc/cfg2html/
        # [   77s] cp: cannot stat `etc/default.conf': No such file or directory
-	cp -av etc/default.conf debian/cfg2html/usr/share/cfg2html/etc/cfg2html/
+       # This still appears to be broken, as on Ubuntu systems, it should go into # modified on 20201114 by edrulrd
+       # /usr/share/cfg2html/etc when installed and not into /usr/share/cfg2html/etc/cfg2html
+       # If SUSE needs it where it was, we can put it in both places
+	cp -av etc/default.conf debian/cfg2html/usr/share/cfg2html/etc/cfg2html
+	cp -av etc/default.conf debian/cfg2html/usr/share/cfg2html/etc/
 	cp -av etc/local.conf debian/cfg2html/etc/cfg2html/
 	cp -av ../cfg2html debian/cfg2html/usr/sbin/
 	cp -av cfg2html-linux.sh debian/cfg2html/usr/share/cfg2html/

--- a/linux/packaging/rpm/cfg2html.spec
+++ b/linux/packaging/rpm/cfg2html.spec
@@ -5,6 +5,10 @@
 %if 0%{?sles_version} == 0
 %undefine sles_version
 %endif
+### Recently in CentOS8, RHEL8, etc, rpmbuild's macros now check for a proper shebang (#!) in the 1st line
+### of the scripts.  Since our scripts are callable by bash, and ksh, we don't have a shebang in our
+### scripts. This disables that checking.  #modifed on 20201115 by edrulrd
+%undefine __brp_mangle_shebangs
 
 Name:		cfg2html
 Version: 6.16


### PR DESCRIPTION
Allow cfg2html to be installed properly on rpm and debian based systems.
Ed