### PR TITLE
Fix SOURCE directory for RPM build

### DIFF
--- a/linux/Makefile
+++ b/linux/Makefile
@@ -215,6 +215,7 @@ rpm: dist
 	cd .. ; \
 	rpmbuild -tb  \
 		--define "_rpmfilename %%{NAME}-%%{VERSION}-%%{RELEASE}.%%{ARCH}.rpm" \
+		--define "_sourcedir %(pwd)" \
 		--define "debug_package %{nil}" \
 		--define "_rpmdir %(pwd)" $(name)-$(distversion).tar.gz
 


### PR DESCRIPTION
rpmbuild looks in _sourcedir to find where the source files for a build are.  By default this is the SOURCE directory in rpm build tree.
This sets it to the local directory.