### PR TITLE
Fix date command in netbackup bcpimagelist

### DIFF
--- a/linux/cfg2html-linux.sh
+++ b/linux/cfg2html-linux.sh
@@ -2128,7 +2128,7 @@ then # else skip to next paragraph
           if [ -x /usr/openv/netbackup/bin/bpclimagelist ] ; then
             exec_command "${TIMEOUTCMD} 20 /usr/openv/netbackup/bin/bpclimagelist | head -12" "Overview of the last 10 backups"
             LASTFULL=$(${TIMEOUTCMD} 20 /usr/openv/netbackup/bin/bpclimagelist | grep Full | head -1 | cut -c1-10)
-            [[ -z "${LASTFULL}" ]] && LASTFULL=$(date +%d/%m/%Y) # if no output was retrieved we use today's date
+            [[ -z "${LASTFULL}" ]] && LASTFULL=$(date +%m/%d/%Y) # if no output was retrieved we use today's date
             LASTFULLSEC=$(date +%s -d ${LASTFULL})
             sleep 1 # to have at least 1 sec difference
             NOWSEC=$(date +%s)


### PR DESCRIPTION
I encountered this little hiccup on a system with Netbackup:

 * `date +%d/%m/%Y` is not expected format, should be m/d/Y
 * fixes crash with these messages:
    * `date: invalid date '19/07/2022'`
    * `cfg2html-linux.sh: line xxx: (1658233237 - ) /86400 : syntax error: operand expected (error token is ") /86400 ")`