### PR TITLE
Insert ZFS from BSD Module, to Linux so it exports zfs on linux

### DIFF
--- a/linux/cfg2html-linux.sh
+++ b/linux/cfg2html-linux.sh
@@ -1531,6 +1531,29 @@ then # else skip to next paragraph
     dec_heading_level
 
 fi # terminates CFG_LVM wrapper
+#
+# CFG_ZFS
+#
+if [ "$CFG_ZFS" != "no" ]
+then # else skip to next paragraph
+   paragraph "ZFS Status"
+   inc_heading_level
+
+   exec_command "zfs mount" "ZFS mount status"
+
+   exec_command "zfs get all" "ZFS properties"
+
+   exec_command "zpool list -H" "ZFS pool status"
+
+   exec_command "zpool list -Ho bootfs" "ZFS boot pool"
+
+   exec_command "zpool upgrade" "ZFS pool version"
+
+   exec_command "zpool history" "ZFS pool history"
+
+  dec_heading_level
+fi
+# terminates CFG_ZFS wrapper
 
 ###########################################################################
 if [ "${CFG_NETWORK}" != "no" ]

--- a/linux/cfg2html-linux.sh
+++ b/linux/cfg2html-linux.sh
@@ -1236,6 +1236,10 @@ then # else skip to next paragraph
     AddText "$(dpkg --version|grep program)"
     exec_command "grep -vE '^#|^ *$' /etc/apt/sources.list" "Installed from"
     [ -x /usr/bin/dpigs ] && exec_command "/usr/bin/dpigs" "Largest installed packages"
+    AddText "Debian Settings"
+    AddText "Hint: to reinstall this list use:"
+    AddText "cat this_list | debconf-set-selections -v "
+   [ -x /usr/bin/debconf-get-selections ] && exec_command "/usr/bin/debconf-get-selections" "Debian Pakage Configuration Values"
   fi
   # end Debian
 


### PR DESCRIPTION
Zfs is in the FreeBSD, but ZFs also exists on ubuntu or can be installed on debian.
So it would be good, that it can be configured to be used on Linux.
The command ccdconfig doesnt exist on my system, i think its a freebsd special.
So i Removed it
Can be found in 364 in bsd/cfg2html-bsd.sh