### PR TITLE
Imrpoved Handeling, so output only apears when it is used

### DIFF
--- a/linux/cfg2html-linux.sh
+++ b/linux/cfg2html-linux.sh
@@ -1236,10 +1236,12 @@ then # else skip to next paragraph
     AddText "$(dpkg --version|grep program)"
     exec_command "grep -vE '^#|^ *$' /etc/apt/sources.list" "Installed from"
     [ -x /usr/bin/dpigs ] && exec_command "/usr/bin/dpigs" "Largest installed packages"
-    AddText "Debian Settings"
-    AddText "Hint: to reinstall this list use:"
-    AddText "cat this_list | debconf-set-selections -v "
-   [ -x /usr/bin/debconf-get-selections ] && exec_command "/usr/bin/debconf-get-selections" "Debian Pakage Configuration Values"
+    if [ -x /usr/bin/debconf-get-selections ]; then
+      AddText "Debian Settings"
+      AddText "Hint: to reinstall this list use:"
+      AddText "cat this_list | debconf-set-selections -v "
+      exec_command "/usr/bin/debconf-get-selections" "Debian Pakage Configuration Values"
+    fi
   fi
   # end Debian
 


### PR DESCRIPTION
On my Pull Request for zfs, a commit i done after on my repo got also committed.
This Part was not quite finished. This is now the Improved version for better output.

This is when debconf-utils is installed, with it you can read and write debian settings like 
debconf-utils
I dont know if, if not it should be added to
cfg2html/linux/packaging/debian/control
On the line
Depends: bash (>=2.0), debianutils(>=1.16), coreutils, psmisc
