### PR TITLE
Broken in AIX, if using a UTF-8 locale

### DIFF
--- a/cfg2html
+++ b/cfg2html
@@ -39,14 +39,14 @@ CVS="$Id: cfg2html,v 7.1.2 2024/09/27 07:09:40 ralph Exp $"     ## Hardcoded....
 PROGRAM=$(echo ${CVS}|cut -f2 -d" "|cut -f1 -d,)
 VERSION=$(echo ${CVS}|cut -f3 -d" ")
 RELEASE_DATE="2025-01-02"	## YYYY-MM-DD ?!
-OS="$(uname)"
-OS="$(echo ${OS} | tr 'A-Z' 'a-z' | sed -e 's/-//')"
 CFG_CMDLINE=$*
 COPYRIGHT="Copyright (C) 1999-2025 by ROSE SWE, Dipl.-Ing. Ralph Roth"
 LANG="C"
 LANG_ALL="C"            # [20200310] {jcw} added LC_COLLATE.
 LC_COLLATE="POSIX"
 LC_MESSAGE="C"
+OS="$(uname)"
+OS="$(echo ${OS} | tr 'A-Z' 'a-z' | sed -e 's/-//')"
 
 ## maybe we should skip the root check if the command line option -h or -? is passed?
 if  [ "$(whoami)" != "root" -a "$1" != "-h" ]


### PR DESCRIPTION
AFAIK the options are:
- move the OS detection after setting locale
- use "tr '[:upper:]' '[:lower:]'" instead of "tr '[A-Z]' '[a-z]'"