### PR TITLE
fix: exit tcpstat & ipstat after count runs

### DIFF
--- a/sunos/cfg2html-SunOS.sh
+++ b/sunos/cfg2html-SunOS.sh
@@ -990,9 +990,9 @@ then # else skip to next paragraph
 
    exec_command "netstat -s" "Summary statistics for each protocol"
 
-   exec_command "tcpstat -c 1" "Tcpstat"
+   exec_command "tcpstat -c 1 60" "Tcpstat"
 
-   exec_command "ipstat -c 1" "Ipstat"
+   exec_command "ipstat -c 1 60" "Ipstat"
 
    exec_command "arp -a" "ARP table"
 


### PR DESCRIPTION
These two calls don't terminate on
SunOS 5.11 11.4.0.15.0 sun4v sparc sun4v:

- tcpstat -c 1
- ipstat -c 1

Tweaked the calls to collect 60 seconds of data.
See https://github.com/cfg2html/cfg2html/issues/211