### PR TITLE
Issue 231 - move postinstall script into post section of rpm spec file

### DIFF
--- a/linux/cfg2html.postinst
+++ b/linux/cfg2html.postinst
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Name: postinst
+#
+# Purpose: automatically run commands in the package manager after
+#          cfg2html has been installed (tested using apt, dnf, and zypper).
+#          Debian and Redhat-based systems are supported.
+#          This script copies the model "local.conf" file from
+#          /usr/share/cfg2html/etc/local.conf into
+#          /etc/cfg2html/local.conf, but only if it doesn't already exist.
+#
+# Author: Ed Drouillard (edrulrd) on Feb 22, 2025
+#
+
+echo "Running post install script"
+
+[[   -d /etc/cfg2html/ ]] &&
+[[ ! -e /etc/cfg2html/local.conf ]] &&
+[[   -e /usr/share/cfg2html/etc/local.conf ]] &&
+echo "Setting /etc/cfg2html/local.conf" &&
+cp -av /usr/share/cfg2html/etc/local.conf /etc/cfg2html/
+
+exit 0


### PR DESCRIPTION
To avoid _sourcedir issues we better move the content of the script directly under the post section in the spec file